### PR TITLE
Fix for Windows systems

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function createStream(options) {
   var readable = rtmpdump.stdout;
 
   rtmpdump.stderr
-    .pipe(split('\x0d'))
+    .pipe(split('/\x0d(?!\x0a)/'))
     .once('data', function(chunk) {
       // when split by \x0d the first chunk is status / stream info
       var info = parseInfo(chunk);


### PR DESCRIPTION
The split command wasn't doing the right thing due to the way windows encodes a newline.
Now it splits only if there is a CR without a LF which is the intended behaviour.
